### PR TITLE
Update picobrew_api.py

### DIFF
--- a/blueprints/picobrew_api.py
+++ b/blueprints/picobrew_api.py
@@ -21,6 +21,7 @@ logger = logging.getLogger()
 
 # ----------- RECIPES -----------
 @picobrew_api.route("/API/SyncUser")
+@picobrew_api.route("/API/SyncUSer")
 @use_kwargs(
     {"user": fields.Str(required=True), "machine": fields.Str(required=True)},
     location="querystring",


### PR DESCRIPTION
In the latest Zymatic FW (1.1.14), uses Get  /API/SyncUSer and not Get  /API/SyncUser