### PR TITLE
fixes UI bug where Temperature is F when it should be C

### DIFF
--- a/picobrew_server/templates/validate.html
+++ b/picobrew_server/templates/validate.html
@@ -42,7 +42,7 @@
                                     </th>
                                     <th data-field="temp">
                                         <i class="material-icons left">assessment</i>
-                                        Temperature (°F)
+                                        Temperature (°C)
                                     </th>
                                     <th data-field="time">
                                         <i class="material-icons left">schedule</i>


### PR DESCRIPTION
After uploading a Recipe, the Mash Schedule is displayed.  The UI display Temperature in Fahrenheit when in actuality the results are displayed in Celsius.

This PR fixes this.  
Also this fixes Issue#5