### PR TITLE
Port BeerXML layer to pybeerxml 3.0 (pydantic-xml)

### DIFF
--- a/picobrew_server/beerxml/picobrew_kegsmart.py
+++ b/picobrew_server/beerxml/picobrew_kegsmart.py
@@ -1,0 +1,16 @@
+from pybeerxml.base import BeerXmlModel, LenientFloat
+from pydantic_xml import element, wrapped
+
+
+class PicoBrewKegSmartStep(BeerXmlModel, tag="STEP"):
+    number: int | None = element(tag="NUMBER", default=None)
+    name: str | None = element(tag="NAME", default=None)
+    time: LenientFloat = element(tag="TIME", default=None)
+    temp: LenientFloat = element(tag="TEMP", default=None)
+
+
+class PicoBrewKegSmartProgram(BeerXmlModel, tag="KEGSMART"):
+    # PicoBrew KegSmart fermentation instructions, not part of the BeerXML spec.
+    # Nothing consumes these yet - they are modelled so the block survives a write-back,
+    # since pybeerxml silently drops any tag that is not a declared field.
+    steps: list[PicoBrewKegSmartStep] = wrapped("STEPS", element(tag="STEP"), default_factory=list)

--- a/picobrew_server/beerxml/picobrew_parser.py
+++ b/picobrew_server/beerxml/picobrew_parser.py
@@ -1,51 +1,19 @@
 from pathlib import Path
-from typing import cast
-from xml.etree import ElementTree
 
-from pybeerxml import Parser
-from pybeerxml.recipe import Recipe
+from picobrew_server.beerxml.picobrew_recipe import PicoBrewRecipe, PicoBrewRecipes
 
-from picobrew_server.beerxml.picobrew_program_step import PicoBrewProgramStep
-from picobrew_server.beerxml.picobrew_recipe import PicoBrewRecipe
+__all__ = ["PicoBrewRecipe", "PicoBrewRecipeParser"]
 
 
 class PicoBrewRecipeParser:
-    def __init__(self):
-        self._parser = Parser()
-
     def parse(self, xml_file: str | Path) -> list[PicoBrewRecipe]:
         path = Path(xml_file)
 
-        # Parse the BeerXML file
-        raw_recipes = self._parser.parse(str(path))
+        # Read as bytes so that ElementTree honours the encoding declared in the
+        # XML prolog (PicoBrew writes iso-8859-1, not utf-8).
+        recipes = PicoBrewRecipes.from_xml(path.read_bytes()).recipes
 
-        # Cast all recipes to PicoBrewRecipes
-        recipes = [PicoBrewRecipe.from_beerxml_recipe(recipe, path.name) for recipe in raw_recipes]
-
-        # Parse the PicoBrew Program Steps
-        programs = self._parse_zymatic_heating_steps(path)
-
-        # merge the parsed recipes with the PicoBrew program steps
-        for recipe, steps in zip(recipes, programs):
-            recipe.steps = steps
+        for recipe in recipes:
+            recipe.filename = path.name
 
         return recipes
-
-    def _parse_zymatic_heating_steps(self, xml_file: Path) -> list[list[PicoBrewProgramStep]]:
-        # Extract the PicoBrew Zymatic/Z(?) specific heating/timing instructions from a recipe
-        programs = []
-
-        with xml_file.open("r") as recipe_file:
-            tree = ElementTree.parse(recipe_file)
-
-        for program_node in tree.iterfind(".//ZYMATIC"):
-            steps = []
-            for step_node in list(program_node):
-                if step_node.tag.lower() == "step":
-                    step = PicoBrewProgramStep()
-                    self._parser.nodes_to_object(step_node, cast(Recipe, step))
-                    steps.append(step)
-
-            programs.append(steps)
-
-        return programs

--- a/picobrew_server/beerxml/picobrew_program_step.py
+++ b/picobrew_server/beerxml/picobrew_program_step.py
@@ -1,13 +1,24 @@
-from dataclasses import dataclass
+from pybeerxml.base import BeerXmlModel, LenientFloat
+from pydantic_xml import element
+
+# PicoBrew encodes the brewing location of a step as a numeric id on the wire
+LOCATION_IDS = {
+    "PassThrough": 0,
+    "Mash": 1,
+    "Adjunct1": 2,
+    "Adjunct2": 3,
+    "Adjunct3": 4,
+    "Adjunct4": 5,
+    "Pause": 6,  # TODO Verify this
+}
 
 
-@dataclass
-class PicoBrewProgramStep:
-    name: str | None = None
-    temp: float | None = None
-    time: float | None = None
-    location: str | None = None
-    drain: float | None = None
+class PicoBrewProgramStep(BeerXmlModel, tag="STEP"):
+    name: str | None = element(tag="NAME", default=None)
+    temp: float | None = element(tag="TEMP", default=None)
+    time: float | None = element(tag="TIME", default=None)
+    location: str | None = element(tag="LOCATION", default=None)
+    drain: float | None = element(tag="DRAIN", default=None)
 
     def serialize(self) -> str:
         assert self.name is not None
@@ -16,15 +27,13 @@ class PicoBrewProgramStep:
         assert self.location is not None
         assert self.drain is not None
 
-        location_id_map = {
-            "PassThrough": 0,
-            "Mash": 1,
-            "Adjunct1": 2,
-            "Adjunct2": 3,
-            "Adjunct3": 4,
-            "Adjunct4": 5,
-            "Pause": 6,  # TODO Verify this
-        }
-
         # e.g. Heat to Temp,102,0,0,0
-        return f"{self.name},{int(self.temp)},{int(self.time)},{location_id_map[self.location]},{int(self.drain)}"
+        return f"{self.name},{int(self.temp)},{int(self.time)},{LOCATION_IDS[self.location]},{int(self.drain)}"
+
+
+class PicoBrewZymaticProgram(BeerXmlModel, tag="ZYMATIC"):
+    # PicoBrew Zymatic/Z specific heating/timing instructions, not part of the BeerXML spec
+    mash_temp: LenientFloat = element(tag="MASH_TEMP", default=None)
+    mash_time: LenientFloat = element(tag="MASH_TIME", default=None)
+    boil_temp: LenientFloat = element(tag="BOIL_TEMP", default=None)
+    steps: list[PicoBrewProgramStep] = element(tag="STEP", default_factory=list)

--- a/picobrew_server/beerxml/picobrew_recipe.py
+++ b/picobrew_server/beerxml/picobrew_recipe.py
@@ -1,8 +1,12 @@
 import hashlib
+from typing import Annotated
 
+from pybeerxml.base import BeerXmlModel
 from pybeerxml.recipe import Recipe
+from pydantic_xml import NoXml, element
 
-from picobrew_server.beerxml.picobrew_program_step import PicoBrewProgramStep
+from picobrew_server.beerxml.picobrew_kegsmart import PicoBrewKegSmartProgram
+from picobrew_server.beerxml.picobrew_program_step import PicoBrewProgramStep, PicoBrewZymaticProgram
 
 
 def get_hash(text: str) -> str:
@@ -11,23 +15,21 @@ def get_hash(text: str) -> str:
     return hasher.hexdigest()[:32]
 
 
-class PicoBrewRecipe(Recipe):
-    def __init__(self, filename: str):
-        super().__init__()
+class PicoBrewRecipe(Recipe, tag="RECIPE"):
+    # Not part of the XML document. NoXml keeps pydantic-xml from binding it to the element text.
+    filename: Annotated[str, NoXml] = ""
 
-        # create a unique id for every recipe based on the filename
-        self.id = get_hash(filename)
-        self.steps: list[PicoBrewProgramStep] = []
+    zymatic: PicoBrewZymaticProgram | None = element(tag="ZYMATIC", default=None)
+    kegsmart: PicoBrewKegSmartProgram | None = element(tag="KEGSMART", default=None)
 
-    @classmethod
-    def from_beerxml_recipe(cls, recipe: Recipe, filename: str) -> "PicoBrewRecipe":
-        picobrew_recipe = PicoBrewRecipe(filename)
+    @property
+    def id(self) -> str:
+        # a unique id for every recipe, derived from the filename
+        return get_hash(self.filename)
 
-        # Copy all properties of the BeerXML object
-        for key, value in recipe.__dict__.items():
-            picobrew_recipe.__dict__[key] = value
-
-        return picobrew_recipe
+    @property
+    def steps(self) -> list[PicoBrewProgramStep]:
+        return self.zymatic.steps if self.zymatic else []
 
     def serialize(self) -> str:
         return f"{self.name}/{self.id}/{self.get_recipe_steps()}/"
@@ -36,5 +38,7 @@ class PicoBrewRecipe(Recipe):
         steps = [step.serialize() for step in self.steps]
         return "/".join(steps)
 
-    def save(self) -> None:
-        pass
+
+class PicoBrewRecipes(BeerXmlModel, tag="RECIPES"):
+    # Overrides pybeerxml's own container so that parsing yields PicoBrewRecipes
+    recipes: list[PicoBrewRecipe] = element(tag="RECIPE", default_factory=list)

--- a/picobrew_server/blueprints/frontend.py
+++ b/picobrew_server/blueprints/frontend.py
@@ -84,6 +84,16 @@ def submit_eula() -> Response:
 
 
 # -------- Template Utility --------
+def to_float(value: float | str | None) -> float | None:
+    # BeerXML fields are lenient: a non-numeric value in the file arrives here as a string
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 @frontend.context_processor
 def utility_processor() -> dict[str, Callable[..., str]]:
     def format_weight(amount: float, _unit: str = "kg") -> str:
@@ -99,8 +109,11 @@ def utility_processor() -> dict[str, Callable[..., str]]:
     def format_volume(volume: float, unit: str = "L") -> str:
         return f"{volume:.2f}{unit}"
 
-    def format_float(value: float, trailing_numbers: int) -> str:
-        return "{0:.{1}f}".format(value, trailing_numbers)
+    def format_float(value: float | str | None, trailing_numbers: int) -> str:
+        number = to_float(value)
+        if number is None:
+            return "n/a"
+        return "{0:.{1}f}".format(number, trailing_numbers)
 
     # Standard SRM to hex color mapping (https://en.wikipedia.org/wiki/Standard_Reference_Method)
     SRM_COLORS = [
@@ -146,10 +159,12 @@ def utility_processor() -> dict[str, Callable[..., str]]:
         "#36080A",
     ]
 
-    def srm_color(srm: float | None) -> str:
-        if srm is None:
+    def srm_color(srm: float | str | None) -> str:
+        value = to_float(srm)
+        if value is None:
             return SRM_COLORS[5]
-        index = max(1, min(round(srm), len(SRM_COLORS)))
+
+        index = max(1, min(round(value), len(SRM_COLORS)))
         return SRM_COLORS[index - 1]
 
     return dict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "Flask>=3.0",
     "Flask-Cors>=4.0",
     "webargs>=8.0",
-    "pybeerxml>=1.2.0",
+    "pybeerxml>=3.0.0",
 ]
 
 [project.urls]

--- a/tests/beerxml/test_picobrew_parser.py
+++ b/tests/beerxml/test_picobrew_parser.py
@@ -30,7 +30,7 @@ def _make_xml(tmp_path: Path, name: str, zymatic_steps: str) -> Path:
 </RECIPES>"""
     path = tmp_path / f"{name.lower().replace(' ', '_')}.xml"
     path.write_text(xml)
-    
+
     return path
 
 
@@ -134,7 +134,10 @@ class TestZymaticStepParsing:
 
     def test_non_step_zymatic_children_ignored(self, parser, tmp_path):
         # MASH_TEMP / MASH_TIME / BOIL_TEMP are siblings of STEP but not STEPs
-        xml_path = _make_xml(tmp_path, "Filtered", """
+        xml_path = _make_xml(
+            tmp_path,
+            "Filtered",
+            """
 <ZYMATIC>
   <MASH_TEMP>67</MASH_TEMP>
   <MASH_TIME>90</MASH_TIME>
@@ -147,7 +150,8 @@ class TestZymaticStepParsing:
     <DRAIN>0</DRAIN>
   </STEP>
 </ZYMATIC>
-""")
+""",
+        )
         steps = parser.parse(xml_path)[0].steps
         assert len(steps) == 1
         assert steps[0].name == "Only Step"
@@ -225,3 +229,86 @@ class TestAlwaysAle6010_2Integration:
     def test_chill_step(self, parser):
         step = parser.parse(ALWAYS_ALE_XML)[0].steps[7]
         assert step.serialize() == "Mash Out,79,10,1,8"
+
+
+class TestZymaticProgramMetadata:
+    def test_mash_and_boil_settings_parsed(self, parser):
+        zymatic = parser.parse(PARTY_PORTER_XML)[0].zymatic
+        assert zymatic is not None
+        assert zymatic.mash_temp == 67.0
+        assert zymatic.mash_time == 90.0
+        assert zymatic.boil_temp == 97.0
+
+    def test_zymatic_is_none_without_section(self, parser, no_zymatic_xml):
+        assert parser.parse(no_zymatic_xml)[0].zymatic is None
+
+
+class TestKegSmartParsing:
+    def test_step_count(self, parser):
+        kegsmart = parser.parse(PARTY_PORTER_XML)[0].kegsmart
+        assert kegsmart is not None
+        assert len(kegsmart.steps) == 2
+
+    def test_step_values(self, parser):
+        step = parser.parse(PARTY_PORTER_XML)[0].kegsmart.steps[0]
+        assert step.number == 1
+        assert step.name == "Fermentation"
+        assert step.time == 14400.0
+        assert step.temp == 18.0
+
+    def test_kegsmart_is_none_without_section(self, parser, no_zymatic_xml):
+        assert parser.parse(no_zymatic_xml)[0].kegsmart is None
+
+    def test_kegsmart_without_zymatic(self, parser, tmp_path):
+        # KEGSMART and ZYMATIC are independent - a recipe may carry only one of them
+        xml_path = _make_xml(
+            tmp_path,
+            "Keg Only",
+            """
+<KEGSMART>
+  <STEPS>
+    <STEP>
+      <NUMBER>1</NUMBER>
+      <NAME>Fermentation</NAME>
+      <TIME>14400</TIME>
+      <TEMP>18</TEMP>
+    </STEP>
+  </STEPS>
+</KEGSMART>
+""",
+        )
+        recipe = parser.parse(xml_path)[0]
+        assert recipe.steps == []
+        assert recipe.kegsmart is not None
+        assert len(recipe.kegsmart.steps) == 1
+
+
+class TestRoundTrip:
+    # pybeerxml silently drops any tag that is not a declared field, so the custom
+    # PicoBrew blocks only survive serialization because they are modelled.
+    def test_custom_blocks_preserved(self, parser):
+        xml = parser.parse(PARTY_PORTER_XML)[0].to_xml(skip_empty=True).decode()
+        assert "<ZYMATIC>" in xml
+        assert "<MASH_TEMP>67.0</MASH_TEMP>" in xml
+        assert "<KEGSMART>" in xml
+        assert xml.count("<STEP>") == 8  # 6 zymatic + 2 kegsmart
+
+    def test_filename_is_not_serialized(self, parser):
+        xml = parser.parse(PARTY_PORTER_XML)[0].to_xml(skip_empty=True).decode()
+        assert "filename" not in xml
+        assert "Party_Porter.xml" not in xml
+
+    def test_standard_beerxml_fields_preserved(self, parser):
+        xml = parser.parse(PARTY_PORTER_XML)[0].to_xml(skip_empty=True).decode()
+        assert "<NAME>Party Porter</NAME>" in xml
+        assert "<BREWER>PicoBrew Inc</BREWER>" in xml
+
+
+class TestEncoding:
+    def test_latin1_recipe_name(self, parser, tmp_path):
+        # PicoBrew writes iso-8859-1, so the file must not be decoded as utf-8
+        xml = PARTY_PORTER_XML.read_bytes().replace(b"Party Porter", b"P\xe4rty Porter")
+        path = tmp_path / "latin1.xml"
+        path.write_bytes(xml)
+
+        assert parser.parse(path)[0].name == "Pärty Porter"

--- a/tests/beerxml/test_picobrew_recipe.py
+++ b/tests/beerxml/test_picobrew_recipe.py
@@ -1,6 +1,4 @@
-from pybeerxml.recipe import Recipe
-
-from picobrew_server.beerxml.picobrew_program_step import PicoBrewProgramStep
+from picobrew_server.beerxml.picobrew_program_step import PicoBrewProgramStep, PicoBrewZymaticProgram
 from picobrew_server.beerxml.picobrew_recipe import PicoBrewRecipe, get_hash
 
 
@@ -12,6 +10,11 @@ def make_step(name: str, temp: float, time: float, location: str, drain: float) 
     step.location = location
     step.drain = drain
     return step
+
+
+def make_recipe(filename: str, name: str | None = None, steps: list[PicoBrewProgramStep] | None = None):
+    zymatic = PicoBrewZymaticProgram(steps=steps) if steps is not None else None
+    return PicoBrewRecipe(filename=filename, name=name, zymatic=zymatic)
 
 
 class TestGetHash:
@@ -31,93 +34,62 @@ class TestGetHash:
         assert len(result) == 32
 
 
-class TestPicoBrewRecipeInit:
+class TestPicoBrewRecipeId:
     def test_id_is_hash_of_filename(self):
-        recipe = PicoBrewRecipe("my_recipe.xml")
+        recipe = make_recipe("my_recipe.xml")
         assert recipe.id == get_hash("my_recipe.xml")
 
     def test_different_filenames_produce_different_ids(self):
-        assert PicoBrewRecipe("a.xml").id != PicoBrewRecipe("b.xml").id
+        assert make_recipe("a.xml").id != make_recipe("b.xml").id
 
-    def test_steps_is_empty_list(self):
-        recipe = PicoBrewRecipe("my_recipe.xml")
+    def test_id_tracks_filename_reassignment(self):
+        recipe = make_recipe("a.xml")
+        recipe.filename = "b.xml"
+        assert recipe.id == get_hash("b.xml")
+
+    def test_steps_is_empty_list_without_zymatic(self):
+        recipe = make_recipe("my_recipe.xml")
+        assert recipe.zymatic is None
         assert recipe.steps == []
-
-
-class TestFromBeerxmlRecipe:
-    def test_copies_name(self):
-        base = Recipe()
-        base.name = "My IPA"
-        result = PicoBrewRecipe.from_beerxml_recipe(base, "my_ipa.xml")
-        assert result.name == "My IPA"
-
-    def test_copies_og(self):
-        base = Recipe()
-        base.og = 1.065
-        result = PicoBrewRecipe.from_beerxml_recipe(base, "recipe.xml")
-        assert result.og == 1.065
-
-    def test_copies_fg(self):
-        base = Recipe()
-        base.fg = 1.012
-        result = PicoBrewRecipe.from_beerxml_recipe(base, "recipe.xml")
-        assert result.fg == 1.012
-
-    def test_id_is_hash_of_filename(self):
-        # id is set by PicoBrewRecipe.__init__ and not overwritten by Recipe.__dict__
-        # (pybeerxml's Recipe has no 'id' attribute)
-        base = Recipe()
-        base.name = "Test"
-        result = PicoBrewRecipe.from_beerxml_recipe(base, "test_file.xml")
-        assert result.id == get_hash("test_file.xml")
-
-    def test_returns_picobrew_recipe_instance(self):
-        result = PicoBrewRecipe.from_beerxml_recipe(Recipe(), "recipe.xml")
-        assert isinstance(result, PicoBrewRecipe)
-
-    def test_steps_is_empty_after_conversion(self):
-        result = PicoBrewRecipe.from_beerxml_recipe(Recipe(), "recipe.xml")
-        assert result.steps == []
 
 
 class TestSerialize:
     def test_format_is_name_slash_id_slash_steps_slash(self):
-        recipe = PicoBrewRecipe("test.xml")
-        recipe.name = "My IPA"
+        recipe = make_recipe("test.xml", name="My IPA")
         # empty steps → get_recipe_steps() returns "", so format yields "name/id//"
         assert recipe.serialize() == f"My IPA/{get_hash('test.xml')}//"
 
     def test_includes_serialized_steps(self):
-        recipe = PicoBrewRecipe("test.xml")
-        recipe.name = "Ale"
-        recipe.steps = [make_step("Heat", 67.0, 0.0, "PassThrough", 0.0)]
+        recipe = make_recipe("test.xml", name="Ale", steps=[make_step("Heat", 67.0, 0.0, "PassThrough", 0.0)])
         assert recipe.serialize() == f"Ale/{get_hash('test.xml')}/Heat,67,0,0,0/"
 
     def test_multiple_steps_joined_by_slash(self):
-        recipe = PicoBrewRecipe("test.xml")
-        recipe.name = "Ale"
-        recipe.steps = [
-            make_step("Heat", 67.0, 0.0, "PassThrough", 0.0),
-            make_step("Mash", 67.0, 60.0, "Mash", 5.0),
-        ]
+        recipe = make_recipe(
+            "test.xml",
+            name="Ale",
+            steps=[
+                make_step("Heat", 67.0, 0.0, "PassThrough", 0.0),
+                make_step("Mash", 67.0, 60.0, "Mash", 5.0),
+            ],
+        )
         assert recipe.serialize() == f"Ale/{get_hash('test.xml')}/Heat,67,0,0,0/Mash,67,60,1,5/"
 
 
 class TestGetRecipeSteps:
     def test_empty_steps_returns_empty_string(self):
-        recipe = PicoBrewRecipe("test.xml")
-        assert recipe.get_recipe_steps() == ""
+        assert make_recipe("test.xml").get_recipe_steps() == ""
 
     def test_single_step(self):
-        recipe = PicoBrewRecipe("test.xml")
-        recipe.steps = [make_step("Heat", 67.0, 0.0, "PassThrough", 0.0)]
+        recipe = make_recipe("test.xml", steps=[make_step("Heat", 67.0, 0.0, "PassThrough", 0.0)])
         assert recipe.get_recipe_steps() == "Heat,67,0,0,0"
 
     def test_multiple_steps_joined_by_slash(self):
-        recipe = PicoBrewRecipe("test.xml")
-        recipe.steps = [
-            make_step("Heat", 67.0, 0.0, "PassThrough", 0.0),
-            make_step("Mash", 67.0, 90.0, "Mash", 8.0),
-            make_step("Boil", 97.0, 60.0, "Adjunct1", 5.0),
-        ]
+        recipe = make_recipe(
+            "test.xml",
+            steps=[
+                make_step("Heat", 67.0, 0.0, "PassThrough", 0.0),
+                make_step("Mash", 67.0, 90.0, "Mash", 8.0),
+                make_step("Boil", 97.0, 60.0, "Adjunct1", 5.0),
+            ],
+        )
         assert recipe.get_recipe_steps() == "Heat,67,0,0,0/Mash,67,90,1,8/Boil,97,60,2,5"

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "backports-datetime-fromisoformat"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -267,7 +276,7 @@ dev = [
 requires-dist = [
     { name = "flask", specifier = ">=3.0" },
     { name = "flask-cors", specifier = ">=4.0" },
-    { name = "pybeerxml", specifier = ">=1.2.0" },
+    { name = "pybeerxml", specifier = ">=3.0.0" },
     { name = "webargs", specifier = ">=8.0" },
 ]
 
@@ -289,11 +298,160 @@ wheels = [
 
 [[package]]
 name = "pybeerxml"
-version = "2.2.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ca/4e57a081fe3a41788b423af3a0014272136e609155f50201e5f7b38e5728/pybeerxml-2.2.0.tar.gz", hash = "sha256:55d3d941953610083f96ae2fd5c80ac6d41a0699e1804306049b0d4904caecff", size = 59784, upload-time = "2026-04-02T20:05:10.556Z" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-xml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/d6/0ed562c733f4154883bd1cabb73c2b01c28ecf18630d3c12ec8170cd998f/pybeerxml-3.0.0.tar.gz", hash = "sha256:83527754db76300af927b4e5fdb6fda63c4a3381207034235648d852e21349fb", size = 119648, upload-time = "2026-07-20T20:45:32.223Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/6e/bbd1643f5a593da13875fbbd24ebf06675a4837e2fa3ddcbf906b5ef97eb/pybeerxml-2.2.0-py3-none-any.whl", hash = "sha256:edd8b56c5695f4c9f10345563b26e8d90ad4127f29e69f8eeb2ac39375478c30", size = 16853, upload-time = "2026-04-02T20:05:09.231Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ac/9d018c92c88abe5308d1c6247e6ae4b7ad42f9652bcba2492f20397ceede/pybeerxml-3.0.0-py3-none-any.whl", hash = "sha256:e07e3eeb3bde085d9b0cd7ddc0b56fc2f008d5f82d1fe7ec4d360a747eef1f69", size = 20601, upload-time = "2026-07-20T20:45:31.057Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.14.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/71/0ae6d4e0a84faf0cd050033416509c44a19dc6dbec5bfdd3e1318cb1feb4/pydantic-2.14.0a1.tar.gz", hash = "sha256:2c3a5627d48f59725564c41b582328a29fa8d9b1108128ef6710463a0136d4fd", size = 844232, upload-time = "2026-05-22T13:23:43.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4e/15d81754895da3f256273432da60fcb7c885177fefaf495c5b4364fadca5/pydantic-2.14.0a1-py3-none-any.whl", hash = "sha256:61a1ea8d65df95b681c1fab9cd7d01b2472837f798df53dc6d0f41f0c217b061", size = 470439, upload-time = "2026-05-22T13:23:40.57Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/74/319859f70c733f341df03823c8ca27ce9003faaac3ffa3110f3af1c8641a/pydantic_core-2.47.0.tar.gz", hash = "sha256:422c1797a7864b2a9a996435aba92fe571fb80190f67a31edbc1ac040c7b51fe", size = 476601, upload-time = "2026-05-22T13:19:00.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/d6/ca525a6172783affe7ef375a044e902592a31660fe33b4086f1930229d9f/pydantic_core-2.47.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:d4c7148fc6c0bb727139010e15aab198be6c5d00276f83246b417ce69831f9d6", size = 2115717, upload-time = "2026-05-22T13:19:19.586Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/ecaac4f819280412a38da769ffdaded9c0bd4a8ec6736ce5ffe29c99279d/pydantic_core-2.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:497f91a0499fa4ce7ae982756f8a237af19f145d944258c0c991cfb78aee13b0", size = 1948979, upload-time = "2026-05-22T13:18:43.106Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c7/2d86173e778337177a3e97ffd0e5f2cb80092d5d0f5aba645cdcfd6e5d86/pydantic_core-2.47.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6cd3cde901878cce06787608a50c4456b8ad49c2128440c24b96b5624d26937", size = 1973963, upload-time = "2026-05-22T13:20:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/96/5c/9ac15ced0e338a53f459bdc57e19fb2a0663f02ff4f18f8220dde3181cfb/pydantic_core-2.47.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6b02b17e44bcb066b9f3a1d31c0be01a59f81d0b94b5066fdded1a8ccc8f819e", size = 2047588, upload-time = "2026-05-22T13:17:44.109Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/4b/1977b22a9f5e5f1b8b51231aeaab8820047fe8c58dc2d858362e8aa567b5/pydantic_core-2.47.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42feab6c93fa3264708502f5062147073c7e57bc56bc1c44ed00efa53bc1859", size = 2224732, upload-time = "2026-05-22T13:19:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6d/08ef62dda872e66c6a2b7c713bfa54464a979e8d476f2fba4a1000166dfd/pydantic_core-2.47.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3c450c65dfd14eee570756f61c823f8a7a36a3f4f4d46a3945d6225dc8a47d8", size = 2283254, upload-time = "2026-05-22T13:19:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/19/8e07e5e9d72efdceaf316214066e08a54dcc8768d0c161ada61d41513452/pydantic_core-2.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0744954b81a77cfd381760d8b1bf92ba4db57d2da235e695d6fd3c94f741d24d", size = 2091555, upload-time = "2026-05-22T13:20:28.536Z" },
+    { url = "https://files.pythonhosted.org/packages/06/61/0ac2e2c0fb7bd74f16a57c927d0c2f26f1ccf27eafe68a8cd3bf6ecc4d39/pydantic_core-2.47.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:34336a9cdd8b54e0cbc9d3c36b7be7dd828fa10e4209a7e4b0ca4583aa3e696d", size = 2113560, upload-time = "2026-05-22T13:18:06.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/24/b1d6a67933c92b8fb0a3670b3d6378d1fdbda5ff1c423bcdc07e732a7cd5/pydantic_core-2.47.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8623f4e598c9cee799075d0f1ab5174f9f2e7c42b3c5c7d859a97b3c726c84f8", size = 2173137, upload-time = "2026-05-22T13:19:58.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/8a/7af29fbff83ade7cc3f6e5a6a57789974c99f259ff44d275e43eaf4365e4/pydantic_core-2.47.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6143463422e3851187657ff677af0cb04c5e1a2c51c028438ce5f20fbb5cb50d", size = 2179337, upload-time = "2026-05-22T13:20:00.868Z" },
+    { url = "https://files.pythonhosted.org/packages/35/84/37adba776ba15399ea8156deba0fa0b43aeef5cc842b8609277a42701395/pydantic_core-2.47.0-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:152bcbfe9f087716d185f6003be549f2cc6ee3cd4ca67909118e31626afc209b", size = 2317034, upload-time = "2026-05-22T13:19:34.205Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/da/ec315b54c393bc516352c46027bfee5725161e85c5a75dcadc0c1cafebb9/pydantic_core-2.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad7522d6e0cf28192b30f4c9db62e9b7a13ef10652bf8310de27bcb4a6c1c40", size = 2354528, upload-time = "2026-05-22T13:19:52.558Z" },
+    { url = "https://files.pythonhosted.org/packages/53/c1/8a2f7dd44a898da45eb910213d6cef99a35d629748b5cb6249dfa449cfa3/pydantic_core-2.47.0-cp310-cp310-win32.whl", hash = "sha256:e1c8ea447dcfaa7f7d815d07bddb131383275682601878b5711f59fac68045a2", size = 1972816, upload-time = "2026-05-22T13:20:16.878Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c7/c8648c0c47baac5ce612d6d38ba96ed7dc95553df44191d3ee76956348f8/pydantic_core-2.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:df82086e6efb002a8e4f8f787dd2ddf9db46403fe8697b7620111663799b62b8", size = 2073558, upload-time = "2026-05-22T13:17:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e0/0da7149bbd84c438beb208e17174d03a798f2c8ce5a978cbc19fb3052be6/pydantic_core-2.47.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:fe87ccbc39a103709d0a5afa75240c15a94611af129261e9484bef0bc97960b2", size = 2114007, upload-time = "2026-05-22T13:20:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/51/30/362c68ac4dc1a830066bf250850725d95be0567bb6a85434616ac68f5939/pydantic_core-2.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:45882c24324f123037982c65eb8d60da778447e6bc87c82241f81d6c6d2c307e", size = 1948028, upload-time = "2026-05-22T13:19:25.939Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d6/1dd26612212fab9145a2b0d876459764ad04248331cb6f61ab4909fddc43/pydantic_core-2.47.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:983e39b39547772543f3518557d0a86dbb3b7bb58bf8e82faba1e0cfa3e816d9", size = 1972491, upload-time = "2026-05-22T13:20:35.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c4/00b31fd04acf601efff148add88cfe5f3c21f43f872e79f76e4580cfaf18/pydantic_core-2.47.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3eb92447d3a079b945b61b8cbd6c3ec2954de3655c4efa0ebd35b069e472c2a9", size = 2045790, upload-time = "2026-05-22T13:18:25.672Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/33/7d1a8116bde9d259b3289090a2d93b87562001731cdf81d78bef5d1060d8/pydantic_core-2.47.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3af9600c680bec4b8d23c32ddaf7a5d91ed39a2cf758c082e34e860140cdcd87", size = 2223039, upload-time = "2026-05-22T13:20:37.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f6/4c94adcfe1bdaad3f8865a2115bed02e02cba809ffab25c0f85c0cc9b78a/pydantic_core-2.47.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9d6098342d4510a9034a500a53b1d737daf9cfc18a47cd21047d02d7d1587557", size = 2282031, upload-time = "2026-05-22T13:17:41.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4f/7fe179b37f887297a5bfd7b38a4a26cd485748b6b424c43c73a36c02f57b/pydantic_core-2.47.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a891c20be5110deb1904f639f3615ec5022b3495995850d1abe7b8fa1550b5", size = 2088600, upload-time = "2026-05-22T13:17:36.643Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/15/daef331c1571ee986e1410511218c4d58e6ead75e0db735051925caa572b/pydantic_core-2.47.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:13990d357a50078e382b15fa3ce3f08043223b4be3eaeb340b184f54c1a2397a", size = 2112087, upload-time = "2026-05-22T13:19:30.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c7/7cfbb736f9ac501a92171e93bf640d065a13e12dcbcfb7effd21cce2f1ca/pydantic_core-2.47.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a0f7343305387bb5884f24d384b7978ad099a277b27529e592c041a502a37c32", size = 2171199, upload-time = "2026-05-22T13:19:12.183Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/03/48e63b1f7d2088d747dde98b5dd7b89a46fff9173b6c10dc6189289c4aa5/pydantic_core-2.47.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2c5e11bb1be2de2707c9367f364e73091ef30d34be54b3a4564d7421ac1a16bd", size = 2176850, upload-time = "2026-05-22T13:17:39.318Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8b/e653f7723f1dff5c054dada5f5d7f2c294067c087a52188847a0414cff2e/pydantic_core-2.47.0-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:e1b52aa981e034896712460c899ee30707c8c6a385e79bb7648aac76c748a3da", size = 2315368, upload-time = "2026-05-22T13:18:36.365Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ff/5aa6fcde3bd427648fee1a363671d8b4852c716603acd77091fb4cf1fc3d/pydantic_core-2.47.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d57d46021c20d4efc28f69b4ca4670dffbb7bdafa51d1967b747849726ec643b", size = 2351750, upload-time = "2026-05-22T13:19:28.187Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1d/6ee14bea4426d6bc421033d8d6ec69a6938d5773f7bd1d535b221fa48a7b/pydantic_core-2.47.0-cp311-cp311-win32.whl", hash = "sha256:d93c02ae8bd33f73624319d85cba47e754155c5bf104c0c5ca96fcd1f3094939", size = 1971464, upload-time = "2026-05-22T13:20:30.718Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6b/e466253efba866851af6e1094c488b4c5fb6adbfd8993d13e12b2a575541/pydantic_core-2.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:859ca679f00e5feb11b58b616eb7bc0efbb13654be21f5c898e510e27671c900", size = 2070625, upload-time = "2026-05-22T13:18:17.224Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/27/10628ab2df9f2421b6f3b88add9e026f1cb79198be417ee7d684ef0de5d7/pydantic_core-2.47.0-cp311-cp311-win_arm64.whl", hash = "sha256:482667e5b7a3e97b0836f33a716199c4ec6ba9c896ca4db6eae799ec527c1e64", size = 2052484, upload-time = "2026-05-22T13:17:32.654Z" },
+    { url = "https://files.pythonhosted.org/packages/19/23/2daeff7346433ad9a3567852dd7a716329f9a7952dcf1ee74b166271bdc7/pydantic_core-2.47.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:70a7aeba54854f5d97da65cb1a61f000f53df3704cab41cd81d65ab127ddd031", size = 2108216, upload-time = "2026-05-22T13:19:31.898Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/70/2989cb5112b892b7dc13af570ff57d0f383f770fc88bbb644262df1b3017/pydantic_core-2.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0e97329e38228f57fe1f2d91ba0ef39cc75cc1a84fe6ef58942d2fc6cb406bf", size = 1951502, upload-time = "2026-05-22T13:19:54.702Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a6/2417d8b1856cf7579a21e2679f02417b910e4f29120303e2c45137525072/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:faf83e50714837af72f13e9369c50377552a4a74049d4477bed51c7e5822d94b", size = 1975590, upload-time = "2026-05-22T13:17:26.586Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/71/0cd0813355b385bef8fa9a719982e0b44847afedc043b988c9f7c5d02ca9/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f50abe60347bf8afe2b2f58db86cf3ac6e418eec7ffa01d9dc90ba29fc64f243", size = 2055885, upload-time = "2026-05-22T13:20:42.378Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/33/5687c6dcf8ecca106c95b2a49f04a633320ab49961da6e57682db37b4482/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f13b18e7dec056336f29ee77dea3cc5db0271d6215cac7249cc5c61b0a49d293", size = 2235292, upload-time = "2026-05-22T13:19:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/36/98/08e81f1a0f0aa82cfa1a4d07b66eb116740fd6c82ba4baa8f96d4b377132/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3aaabbdbbbb8dff33fa053ffb2c980f39dec745fc03592f50e1e010449129841", size = 2308945, upload-time = "2026-05-22T13:18:38.113Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f1/6e35bdbdb79f96e630265297452d709b2ebd5facfbd83d3eb702eee24939/pydantic_core-2.47.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d2907ee6d15cf26787bfbeb4c42e18e52f358086eab91baea961a0d909248d6", size = 2093861, upload-time = "2026-05-22T13:20:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c4/6a48e5da6a567bcf6d3ab113d2d476e1b93e3be941b4c486918f1c9d6714/pydantic_core-2.47.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:c413761260967f4dbb51135e1b49f30a1c29e15bf371fbb39754ed6475739545", size = 2124948, upload-time = "2026-05-22T13:18:15.728Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a1/e356c98dfc6bd5e6e166f2c832865a62941370b17a7199d35bc5999fecc8/pydantic_core-2.47.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bb527ac6e5a9721023b24615e1a55c01f47c60007f08b7d2afb89ff9c7a0e22", size = 2182065, upload-time = "2026-05-22T13:19:07.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/aa/6e99aac0a891b05cc522cc464aebeec2bb877fa4744be641a013ebc1785a/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b3abf7fd5e6abe483a63413f9cd26b7c93c20780e19c8556434c7279f6b2f10c", size = 2185830, upload-time = "2026-05-22T13:18:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/c6c5c1ad40b4d58f11d6e754e9c3990a2a3cfff20a9cf5c1f0a855a791b2/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:9cefe43d17a5a273d71697c084d3787defa7f578cd5fab4cef4c66d13c9e44b2", size = 2327330, upload-time = "2026-05-22T13:19:48.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f8/064747538297e385a1f197f35551d1bf6093e88c5ce9b4e15c035f0a1cfe/pydantic_core-2.47.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38a8b5371b7938e4f6c31060dbd51d3b3229aef7c43eaac2eb8b153e43c3f189", size = 2366505, upload-time = "2026-05-22T13:20:11.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d5/2d8715ef982c0b1875e42f4248b48439133a2781f0be77f0e4dbc84d147d/pydantic_core-2.47.0-cp312-cp312-win32.whl", hash = "sha256:b87e95e644df2a36bd631dd0d6e097aa73d19a55adf7b1724ebdeece3d9c76b7", size = 1957410, upload-time = "2026-05-22T13:17:38.025Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/ea/9d908a80798db41c7c38926259ed74d015869f0afe4be6ed56f71793a084/pydantic_core-2.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0078c5695322050ccedbc86eafaf3e2548439782c51d99e575de0e31b9fe4f4", size = 2072354, upload-time = "2026-05-22T13:17:42.779Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/78/5549cba47c662ec7f05d79527474786e5ff7f08ef3e65a409a8a2ab6013e/pydantic_core-2.47.0-cp312-cp312-win_arm64.whl", hash = "sha256:7eedc31996e9eba3bdfbbc380805ac6d765c889b7e93b17cd00ecb0200fd6dca", size = 2035452, upload-time = "2026-05-22T13:18:18.75Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/91/810cabda42f7fdd13b349702694e1140f6071fd42d1e542d606d5ad0c2d4/pydantic_core-2.47.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:263560ece98bffbbc0a8047ce60b8a278c859db6a2a4e30d9454b02891045eca", size = 2108548, upload-time = "2026-05-22T13:18:09.878Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/f444a6d63bcbdff3c45291df842941ed56c568f45dd3742f25afb567b5a2/pydantic_core-2.47.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a7fdaff39a66bf66e9037da482575513d2f20bfb02ea9d9222b5cb3b902fc695", size = 1951421, upload-time = "2026-05-22T13:20:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/09/c90dff5407c11e59023161c84df19dd5ed93966a23b2f08cd21d45812ab9/pydantic_core-2.47.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b3e6c8ee5ce8c270bfae09763ae4bbbccfe81090c97d670a621fb86cb1ef6042", size = 1976554, upload-time = "2026-05-22T13:19:04.085Z" },
+    { url = "https://files.pythonhosted.org/packages/95/cf/55fbe9f1b396f91005cd1cb7acf2bcf380a1f1b57e261ac78bcdc0ff42f3/pydantic_core-2.47.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e38cdae682cfec4b3816722dccf6376ca59049726d57dca83c2fe7cc13665589", size = 2055005, upload-time = "2026-05-22T13:18:12.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c6/4f7cbaa62582e95c080cdd45fb5d4350ff05dac87ea32930c75dcb427bf1/pydantic_core-2.47.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fc3193ff0b7e2e168f84c6185e70475738c191f3154e0af8f897cd0f8f9a489", size = 2235489, upload-time = "2026-05-22T13:19:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/31/75/16913c82ffd194c537222b3d0e8a05c11681e551add67308ec4af6023724/pydantic_core-2.47.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:57ff41672a615f38af528ee904602be51c653248354e5db8e9252668abe91e68", size = 2308360, upload-time = "2026-05-22T13:18:39.894Z" },
+    { url = "https://files.pythonhosted.org/packages/05/9f/b24bb1b764fc360adace5df806a81fd62ef1662df2973891e487c3fd5a2c/pydantic_core-2.47.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473b9a2b2a1f0dd55cbb32d2b902f93babe7f141a0bb48fb4d3d4d2b3e93e9a0", size = 2092549, upload-time = "2026-05-22T13:17:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d3/0268ea5972b91178250c0a573bb54c17f697665cd2aa35623087a3589fc6/pydantic_core-2.47.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:195f9c4ac43a7b2a044a7b86631c3352abdb820bed2823ea29f98f779255f459", size = 2123849, upload-time = "2026-05-22T13:18:03.817Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/92/26b2147738a89f78925775bb4b34ae53f981ce880ee77ee2c2ccbc49466a/pydantic_core-2.47.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c1cd10d39ef1ff8bcd68b6865bee9c434631ac0608d402fe86e678851c2e2a5", size = 2181733, upload-time = "2026-05-22T13:17:35.308Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/8a858dde4784c7245b7216ab9a71518cb1a898a83ffb5c0509181789de19/pydantic_core-2.47.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7cbe66352fe2b39511d49150e5b52159429cd21f5633a3e801dd2c43829dcdca", size = 2184065, upload-time = "2026-05-22T13:18:11.369Z" },
+    { url = "https://files.pythonhosted.org/packages/69/20/ea165877f965622e021f04d63330f9ceb55ede0aefa862863e06a9a610cb/pydantic_core-2.47.0-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e35192a1d53e55d510d8bb1023c988c7cdae6d94539074971741b2a7656e49a1", size = 2326881, upload-time = "2026-05-22T13:18:41.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d6/ad22a6f0941be5a5478e6c378d0ec3c7641be96d7a86a3ea1f9e9830a269/pydantic_core-2.47.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:81de54576de2e20baec76cc5afae2820f9049e6fdc4f357bac3391da02d0ba97", size = 2365574, upload-time = "2026-05-22T13:20:02.947Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4e/eb5e3429dd29311e75ab89313cde09b709b0637fd88838d2cb4a98760b02/pydantic_core-2.47.0-cp313-cp313-win32.whl", hash = "sha256:05da6647bdfd3888936ac10aa39b239d659f3c93dff281af0fc5943eb55629dd", size = 1955451, upload-time = "2026-05-22T13:17:31.178Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/ec107c12aa8729c766285d4aa6caa5f5addf8b2ef6cfd35c455a3ca5c66e/pydantic_core-2.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:021220e0a03b66112737ee1fc49759340ce8fafb8d9ade1b7fb366b06033fa45", size = 2071285, upload-time = "2026-05-22T13:19:50.585Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/02/b003a55acfeb35823925d1cd502b80e3fe6c5d477865c36815fbefdf49ac/pydantic_core-2.47.0-cp313-cp313-win_arm64.whl", hash = "sha256:55156ee2f6f561ea4e25ab55f84bd70b9c9ed2546a834cb2b038fe10225aaa37", size = 2034804, upload-time = "2026-05-22T13:18:32.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/46/a4675c783822e229bf04e290ae28cf5a057b00a46039498743b066e0fefd/pydantic_core-2.47.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6e37a6974fbd8fa7cae12285a76970d50b3689ffd6ed7c7fdd176ba81dd22d0e", size = 2104537, upload-time = "2026-05-22T13:18:05.312Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bb/f6d6d1dd8362d616b227b55af8bc2d1b7d4ea842facb7c50a82298ba3b9d/pydantic_core-2.47.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2433b8524785cc117e602233bc574879bc8d87f09523edeec51665d5c46cf42d", size = 1951581, upload-time = "2026-05-22T13:18:14.244Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ae/7d01ed8658ccf8beae8a3fcf2cd023c3ba0ab0b19d3f456845a709cece94/pydantic_core-2.47.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8f9f2be064c8bf1189f46f7062fd42765d94f59cfb7db7ef8db19563192110a", size = 1978461, upload-time = "2026-05-22T13:19:15.829Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e5/dd38ccbd1e68f1c3fd7f8b413a8b32db11bd16d5999c3dc3aed4e54290df/pydantic_core-2.47.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f0a9659a2eb161573418e3138f616101ba21bbd2ff04916dca7b6712155e015", size = 2049444, upload-time = "2026-05-22T13:19:06.258Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/63/0cb998f3f4ea4255ab6d891e2537d4566cd31630df0d406ce45b00306729/pydantic_core-2.47.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2995074b99242aa28991e0120a3c881babc139e08750a05b7ea7d140644e091d", size = 2231772, upload-time = "2026-05-22T13:20:05.22Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/20/2cacf5c4a1bdda1356351df38f343c6cf13af6194e6e0ee0f7967395793f/pydantic_core-2.47.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c5b224dc04c3ff9b08c24419464eb7f6ad7a1049e12284a00bf80df82bd15fdb", size = 2305322, upload-time = "2026-05-22T13:20:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8f/b7e09086bd48b1ef3f74227ed98907496924a622c7f9315cf661946233c6/pydantic_core-2.47.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:264361b7236d4374fef6342908f87d084a0d58a2f8d0811e99f714309cb0ba7e", size = 2097748, upload-time = "2026-05-22T13:20:21.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/27/2927049e93f6fbbaa838b2bb656dbd63c6d6fcaab9909d632fd93573ebd9/pydantic_core-2.47.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:53368beaf693f6302a6e33bdefe950857534a04d282811421bd20176d0fb5636", size = 2122971, upload-time = "2026-05-22T13:19:37.977Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/3b/80b58a0c7f4339f024ad5c5b6316bef895536abf75c45dc85f0c83ae1a92/pydantic_core-2.47.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5d2177b44ba7d9d86850f865f362feeaac6a2ed8517a9b505b97ff0b7fdbd7dd", size = 2181287, upload-time = "2026-05-22T13:18:20.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/0a/dfcb9575603aaf113d2cae1fb622570046a210276eba2267764b3f83f4f2/pydantic_core-2.47.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fb57a6b538ec7a01b937986bc093aec530fb056135b6bc9cfdd0bf8460c25bc2", size = 2177842, upload-time = "2026-05-22T13:17:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c2/31a198c8180b417d18410e7640c505b39c51ac291aca34f71ac37093f4c4/pydantic_core-2.47.0-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:18c9c7c3a18e9bdbf1215d913f6bd00e17595dc92949817935cb87a3cf5f1697", size = 2321802, upload-time = "2026-05-22T13:17:54.495Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/052d872b61f88d2f71b3d881c08abfbe33cb9d64bd988712bb4fb973001c/pydantic_core-2.47.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2f72a382886ca85bb1247303b9134cf9978c9d454de62e710a1ebcd9d2131927", size = 2363870, upload-time = "2026-05-22T13:18:45.053Z" },
+    { url = "https://files.pythonhosted.org/packages/be/60/c8c985d4081dafaa88fe6ac6a41ebe2b82d289c391b2bcbd3508f585e7a9/pydantic_core-2.47.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:cdf4dc2cdd0eacad1bd81c4d25422b4c25b206acae095d2d64e5d5cb7facc6b3", size = 1369335, upload-time = "2026-05-22T13:17:51.719Z" },
+    { url = "https://files.pythonhosted.org/packages/42/70/30dfcc18dc5552f7235ae2ffd7b699a1ba0d38ebfcdb97f371c792d61601/pydantic_core-2.47.0-cp314-cp314-win32.whl", hash = "sha256:1e859dd5e06e9807080e14995db131649a77c61131cc464a7fe492a69ce82488", size = 1952107, upload-time = "2026-05-22T13:20:24.07Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/49/f5c517ba99b9e1036ead16cedd0fc189dbcbf900fb0b85b746b6a0b9b389/pydantic_core-2.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:234ecade0e358caa1ea516c218b3f61e61e30532cad1a8bb12f2487325838548", size = 2071388, upload-time = "2026-05-22T13:18:46.74Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6b95e00ed7a3c7f78cb8544bc34cb29412c05512af507fc4466912576d50/pydantic_core-2.47.0-cp314-cp314-win_arm64.whl", hash = "sha256:58158d0111e86893bc35aacabe509f951ed303cddf8cdba43533190bde317914", size = 2026046, upload-time = "2026-05-22T13:18:22.112Z" },
+    { url = "https://files.pythonhosted.org/packages/22/2c/fa67f96f381ba3c83e8cd75a6eb3c538e123d8d02e19d80383bff01ffda0/pydantic_core-2.47.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:24017fd3befd4d7cc4a8c71f4a1e9a44d29fdc91723c5446b0e795ab808adee7", size = 2102407, upload-time = "2026-05-22T13:17:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e8/99abe6c33db3dda235a2095eae5fdd03266857abd9be1c50ed97a59587c3/pydantic_core-2.47.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dfa0820888cc4549fcce7e6bd8affa7d75198d885ccd0bb0760def4bb8461862", size = 1931963, upload-time = "2026-05-22T13:18:23.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/dd/96d1884f65737f793e64b6b8745ee793e3cb4735e086ead0a40e5349294e/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1d507f331756f7066cde7c9f35ed78fa78223a54369dbc8a34d6da7a5074fa1", size = 1973492, upload-time = "2026-05-22T13:17:22.128Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8c/0504f091c75b229cd07d61b45464d7c5291c3ecf2e7d847f215fe81cf5e5/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c4a885fb50c05903bc703a00830616e680304fdcdd90fc9535a52e72debe712", size = 2035548, upload-time = "2026-05-22T13:17:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bf/e9f69c55ef6c945d29e4afb306f62a15354bfd09f1ee25d9aecd4c6cbb82/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b107cbd764bf68f12a57c7aa5846d868bc7463490a1ac2d0f19bffef624c5a9", size = 2238356, upload-time = "2026-05-22T13:19:10.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/dfbd214487033093f5946c1fd5915ae5dc6b278efe764397b5e2ef8092a8/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b5f46412c8226d0c8f1f423c324c75afe342e4b854836933579fb484f68598c", size = 2284799, upload-time = "2026-05-22T13:17:27.959Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ec/f80488fa26a6b27bd0d1267f35b0fce3bfeec23ca97021085a94ccd3adc3/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90cbf7e35d597503cbdb5cd85409cbb75f377290bc7e8e37cc5dfe4f5cc66cf8", size = 2107895, upload-time = "2026-05-22T13:18:27.282Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1d/67ac210745f63a982b145d8f281dc76bd347d98052792f087224a178da54/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:04ee7ba7172cb4484af51b2890f19069d35773698abc8c6ebb651f52fbf41134", size = 2102797, upload-time = "2026-05-22T13:19:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/75/f3b9bd4d88fcaad9a5abf2ec6969f37a70e34f40a5f8d2d78077f168e83d/pydantic_core-2.47.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2a7acb3e120ddba94372b8146e62ea3a0bce203180e34641c817c87f995c91e0", size = 2160123, upload-time = "2026-05-22T13:19:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/e94ac13bd17c341e86c4b67deb47b63718208fe413034fdb01e7a4bf1dd8/pydantic_core-2.47.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:1a2f7ceb58013d167d8c96f10ec9b3a137018c819ba356f68ff1cb74302fd22e", size = 2164386, upload-time = "2026-05-22T13:18:48.372Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/862ff195402f5b08db9ad4d9ebe7cbed993f51528aab7edcb62531442556/pydantic_core-2.47.0-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:482b097637fec5037eb13fe9f9d5fe47e568a5b451d686bc2b854076cc0b50ca", size = 2303767, upload-time = "2026-05-22T13:18:50.211Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/05/c8ebbb97cf44686fc9cc64a6bb86ac72a8871426a9f61417e395d77c4894/pydantic_core-2.47.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a8c7f5fad73eb404f4b84c75f3d9d3865b748ded248b7366341db6e516fc502b", size = 2361148, upload-time = "2026-05-22T13:18:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/4695ec6ce81eda7cc822383de993c5b2c289cfc84d3f032a30c55eb238fc/pydantic_core-2.47.0-cp314-cp314t-win32.whl", hash = "sha256:f343c39928097175acf2f7d0cba5c00b0f62265d88a173a4ce264266ac849bd9", size = 1939588, upload-time = "2026-05-22T13:19:42.151Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4d/bc2e188ab648b3ab284e80a0340c5d5b9723c22572c6e36ba39eb300e718/pydantic_core-2.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:52d40e074da44e42b2425aedebd513e405a31807036ef597175117a9b01743a6", size = 2049697, upload-time = "2026-05-22T13:18:08.244Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/46/ca1e6813e029993e57340c6a37740450c51919e3809472f79060f4d64cf0/pydantic_core-2.47.0-cp314-cp314t-win_arm64.whl", hash = "sha256:25cac08c9735e61e5c0b9f7a85c438661fc0e9da226afdfa984c3da6c5942a5a", size = 2025906, upload-time = "2026-05-22T13:17:50.322Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a3/7391a9a511aba60ba119dcbc221a36109dd05ff498dcd6e6ff7222a21b76/pydantic_core-2.47.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:dbe50ffd50c7e1b8e3bedafafd10fabe8a7cf51916f995fd57316eb1293f2439", size = 2112946, upload-time = "2026-05-22T13:18:54.846Z" },
+    { url = "https://files.pythonhosted.org/packages/71/74/1d0fe337fa5a89069731206be4da2b41793b8f8fe28f34ed4d941028a62f/pydantic_core-2.47.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:67c3f4b57a1cda846a9b6258e0ef70f99b0757d0b6a55f7e3e5b100620937d2c", size = 1940704, upload-time = "2026-05-22T13:18:00.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/75/d40231aed211f97ffc3264d7a7c98d1f52f7b9c8d165cee75c8c1c13e5c3/pydantic_core-2.47.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33c1e025c83b3987784191ec5aa78cfb94686f1ba73d98ae4d520c09cdecda8d", size = 1985024, upload-time = "2026-05-22T13:17:29.331Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/bc/e27d3fb897c5b059a508b88eb7c4cc1f0fe600be3231728bb003e1e2b464/pydantic_core-2.47.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c547cac87585ab8a6e9495fd3be22ae8ccaabb3c909f6ae589a180677c105cc8", size = 2136202, upload-time = "2026-05-22T13:17:34.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/21/81cc7e3acbf7d4eed41e9585e81b5840aaf6ddbe65974a20946038d6516b/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:d648515c65f8871ceca6a0446be32fb1a0aae414db3907ec0df6cc2380dd0c04", size = 2098016, upload-time = "2026-05-22T13:18:56.902Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6e/c98e869e9f754f18088ad9b55887972d08606e7bf81dba088779e927eb65/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3292813ac8ed17671a5b1ac8256b6e98b96c29c1c6d061c35899e2f6e0444cac", size = 1931175, upload-time = "2026-05-22T13:20:07.566Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/65/ce0d773f4b51dc332764ba1bd585c81f62d5c92231a66d152aff16be8dfa/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf3cfcea028f41a9b42a47f4a53d72ca4274d04e3ee525bd58ca89ea8c5e1910", size = 1995356, upload-time = "2026-05-22T13:19:44.143Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2c/6e63683a77d342c93bad67bb0762ca8fe1d8418acc8617d70ccdcc5ec5ff/pydantic_core-2.47.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52afdd8640d59890539060e91c8a494cf96b463e63b2ba499cc5c23abcb5e96b", size = 2144893, upload-time = "2026-05-22T13:17:59.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/bf/06a01e2f6668aa10646e5c9b050a609d975a93d58454e26e16fd9f82cd38/pydantic_core-2.47.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ff201e8b93cd6a3849ec3fecb1d642d0391ca4a387f1162adaadddfd1986598c", size = 2114751, upload-time = "2026-05-22T13:18:02.245Z" },
+    { url = "https://files.pythonhosted.org/packages/41/50/caf4cc67fdd664baf89bfe264d72079e901a02d903c813ced9de173cdd69/pydantic_core-2.47.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eba39fca6e1fc7c58a5e6b5c320c6eec86014f7075dfa0fb1a79076e00304b3a", size = 1947894, upload-time = "2026-05-22T13:19:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/96ba102865c9ccb945a758272741d00175837bf32bb71750f6e2bf4543fb/pydantic_core-2.47.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b494566e8e7e1a3992a550900902d6c0051538e53f5957e24003e7775638a24", size = 2131698, upload-time = "2026-05-22T13:18:58.55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f8/ee7c5d4eafaecdeaf92ce84f48d748c139888e90fa25b2ae988c5aea874c/pydantic_core-2.47.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c96f745745fe778a92e74f40675c57b80dd46fc98186c9020e5ba4514a0470bd", size = 2157797, upload-time = "2026-05-22T13:17:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/08/69/b3eba1d0e015cee3906f7056cfd9ed383f6cef486fde5398a002df2594e4/pydantic_core-2.47.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:dbfb8f8ac48a8fd5a9f83cdbba0a23796f3ff5f9421c735808ed134d3318046f", size = 2177829, upload-time = "2026-05-22T13:20:09.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/36/a0ceff9b7c3a0980128c9ef763db1e9fe9c2b1fcecf6ed055e88af39f123/pydantic_core-2.47.0-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:4ded2d8dc3beb086623ab3256b81a0b51fc026c94eb363f480aec09b204a1cbd", size = 2307425, upload-time = "2026-05-22T13:19:46.177Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0a/930e210e95ade33ecacabc4ba822aa1662a0aaf843d2cf57abce27fb95b1/pydantic_core-2.47.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:25f8aa59fd3f85651387c37b289cd8f0bbc8f632e7dad13c6b837759e78be88d", size = 2351547, upload-time = "2026-05-22T13:17:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/0c/90941408bb6c1e84563d99177c9e62c536dce0388b5a8bf37b90b4f6f095/pydantic_core-2.47.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:0ae0096729c64aa6155cef74e75d1945017b01cfb82f313a18d843fafc497476", size = 2180871, upload-time = "2026-05-22T13:19:56.696Z" },
+]
+
+[[package]]
+name = "pydantic-xml"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/87/085533e0873b2f80bdeb12156ffe5dddae7ee55573e2057ad574d73e3b6a/pydantic_xml-2.21.0.tar.gz", hash = "sha256:678ba9149c24e190ad94d6e3ce47f94cbb1409fd88d7df65d3d26939ff669ed0", size = 26825, upload-time = "2026-05-17T15:24:19.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/b1/278da37b539595b2cb6bb4fb3da1d69ff084c7bf5cc143f0a444550dc41a/pydantic_xml-2.21.0-py3-none-any.whl", hash = "sha256:966b8990746528304ebb96c97db7603ee3faf38f06266247b1fa444dbc16f8d6", size = 43449, upload-time = "2026-05-17T15:24:21.182Z" },
 ]
 
 [[package]]
@@ -433,6 +591,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pybeerxml 3.0 is a pydantic/pydantic-xml rewrite that removed `Parser.nodes_to_object` and made `Recipe` a validating pydantic model, breaking every parse path.

The PicoBrew tags are now modelled as real fields instead of re-parsing the file: `PicoBrewProgramStep` becomes a `BeerXmlModel`, and `PicoBrewRecipe` declares `ZYMATIC` and `KEGSMART` as `element()` fields on top of `Recipe`. That removes the second `ElementTree` pass, the `nodes_to_object` call and the `__dict__`-copy in `from_beerxml_recipe`.

Recipe ids derive from a `NoXml` `filename` field and `steps` reads through the zymatic program, so the API wire format and templates are unchanged.

Two fixes along the way: recipe files are read as bytes so ElementTree honours the `iso-8859-1` prolog PicoBrew writes (utf-8 decoding raised on non-ASCII names), and `format_float`/`srm_color` tolerate the `LenientFloat` strings that `og`/`fg`/`ibu`/`abv`/`color` can now return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and preserving PicoBrew KegSmart fermentation programs.
  * Improved handling of PicoBrew Zymatic and KegSmart recipe data during XML import and export.
  * Recipe identifiers now derive from their source filenames.

* **Bug Fixes**
  * Improved compatibility with XML files using non-default encodings.
  * Numeric recipe values and SRM colors now handle missing or invalid data gracefully.

* **Tests**
  * Expanded coverage for recipe parsing, serialization, metadata, custom sections, and encoding support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->